### PR TITLE
Changing parameters Path values of the constants

### DIFF
--- a/kernel/boot/init.php
+++ b/kernel/boot/init.php
@@ -146,7 +146,19 @@ $Url 		= new Url();
 $Parsedown 	= new Parsedown();
 $Security	= new Security();
 
-// Relative path logic
+// HTML PATHs
+//$base = (dirname(getenv('SCRIPT_NAME'))==DS)?'/':dirname(getenv('SCRIPT_NAME')).'/';
+$base = empty( $_SERVER['SCRIPT_NAME'] ) ? $_SERVER['PHP_SELF'] : $_SERVER['SCRIPT_NAME'];
+$base = dirname($base);
+
+if($base!=DS) {
+	$base = $base.'/';
+}
+
+if (dirname($_SERVER['SCRIPT_NAME']) == '\\') {
+	$base = '/';
+}
+
 define('HTML_PATH_ROOT', '/');
 
 // Paths for themes

--- a/kernel/boot/init.php
+++ b/kernel/boot/init.php
@@ -146,16 +146,8 @@ $Url 		= new Url();
 $Parsedown 	= new Parsedown();
 $Security	= new Security();
 
-// HTML PATHs
-//$base = (dirname(getenv('SCRIPT_NAME'))==DS)?'/':dirname(getenv('SCRIPT_NAME')).'/';
-$base = empty( $_SERVER['SCRIPT_NAME'] ) ? $_SERVER['PHP_SELF'] : $_SERVER['SCRIPT_NAME'];
-$base = dirname($base);
-
-if($base!=DS) {
-	$base = $base.'/';
-}
-
-define('HTML_PATH_ROOT', $base);
+// Relative path logic
+define('HTML_PATH_ROOT', '/');
 
 // Paths for themes
 define('HTML_PATH_THEMES',		HTML_PATH_ROOT.'themes/');
@@ -173,7 +165,7 @@ define('HTML_PATH_PLUGINS',		HTML_PATH_ROOT.'plugins/');
 define('JQUERY',			HTML_PATH_ADMIN_THEME_JS.'jquery.min.js');
 
 // PHP paths with dependency
-define('PATH_THEME',			PATH_ROOT.'themes/'.$Site->theme().'/');
+define('PATH_THEME',			PATH_ROOT.'themes'.DS.$Site->theme().DS);
 define('PATH_THEME_PHP',		PATH_THEME.'php'.DS);
 define('PATH_THEME_CSS',		PATH_THEME.'css'.DS);
 define('PATH_THEME_JS',			PATH_THEME.'js'.DS);

--- a/kernel/boot/init.php
+++ b/kernel/boot/init.php
@@ -152,11 +152,9 @@ $base = empty( $_SERVER['SCRIPT_NAME'] ) ? $_SERVER['PHP_SELF'] : $_SERVER['SCRI
 $base = dirname($base);
 
 if($base!=DS) {
-	$base = $base.'/';
-}
-
-if (dirname($_SERVER['SCRIPT_NAME']) == '\\') {
-	$base = '/';
+    $base = $base.'/';
+}else{ // work in subdomain
+    $base = '/';
 }
 
 define('HTML_PATH_ROOT', $base);

--- a/kernel/boot/init.php
+++ b/kernel/boot/init.php
@@ -159,7 +159,7 @@ if (dirname($_SERVER['SCRIPT_NAME']) == '\\') {
 	$base = '/';
 }
 
-define('HTML_PATH_ROOT', '/');
+define('HTML_PATH_ROOT', $base);
 
 // Paths for themes
 define('HTML_PATH_THEMES',		HTML_PATH_ROOT.'themes/');


### PR DESCRIPTION
The HTML_PATH_ROOT and PATH_THEME constants are defective; Fail that normally can not display the 'home' page of 'administration'. The .css files are not loaded.
To reproduce the error, use Windows as a server and create a subdomain. Ex .: bludit.example.net