### PR TITLE
[Tags Plugin] Enable sorting & beautify with ucfirst()

### DIFF
--- a/bl-plugins/tags/languages/en_US.json
+++ b/bl-plugins/tags/languages/en_US.json
@@ -3,5 +3,9 @@
 	{
 		"name": "Tags list",
 		"description": "Shows all tags."
-	}
+	},
+	"tag-sort-order": "Sort the tag list by",
+	"tag-sort-alphabetical": "Alphabetical order",
+	"tag-sort-count": "Number of times each tag has been used",
+	"tag-sort-date": "Date each tag was first used"
 }

--- a/bl-plugins/tags/plugin.php
+++ b/bl-plugins/tags/plugin.php
@@ -5,7 +5,8 @@ class pluginTags extends Plugin {
 	public function init()
 	{
 		$this->dbFields = array(
-			'label'=>'Tags'
+			'label'=>'Tags',
+			'sort'=>'date'
 		);
 	}
 
@@ -16,6 +17,19 @@ class pluginTags extends Plugin {
 		$html  = '<div>';
 		$html .= '<label>'.$Language->get('Plugin label').'</label>';
 		$html .= '<input name="label" id="jslabel" type="text" value="'.$this->getDbField('label').'">';
+		$html .= '</div>';
+
+		$html .= '<div>';
+		$html .= $Language->get('tag-sort-order').': <select name="sort">';
+
+		foreach(array('alpha'=>'tag-sort-alphabetical', 'count'=>'tag-sort-count', 'date'=>'tag-sort-date') as $key=>$value) {
+			if ($key == $this->getDbField('sort')) {
+				$html .= '<option value="'.$key.'" selected>'.$Language->get($value).'</option>';
+			} else {
+				$html .= '<option value="'.$key.'">'.$Language->get($value).'</option>';
+			}
+		}
+		$html .= '</select>';
 		$html .= '</div>';
 
 		return $html;
@@ -37,12 +51,28 @@ class pluginTags extends Plugin {
 
 		foreach($db as $tagKey=>$fields)
 		{
-			$count = $dbTags->countPostsByTag($tagKey);
-
-			// Print the parent
-			$html .= '<li><a href="'.HTML_PATH_ROOT.$filter.'/'.$tagKey.'">'.$fields['name'].' ('.$count.')</a></li>';
+			$tagArray[] = array('tagKey'=>$tagKey, 'count'=>$dbTags->countPostsByTag($tagKey), 'name'=>ucfirst($fields['name']));
 		}
 
+		// Sort the array based on options
+		if ($this->getDbField('sort') == "count")
+		{
+			usort($tagArray, function($a, $b) {
+				return $b['count'] - $a['count'];
+			});
+		}
+		elseif ($this->getDbField('sort') == "alpha")
+		{
+			usort($tagArray, function($a, $b) {
+				return strcmp($a['tagKey'], $b['tagKey']);
+			});
+		}
+
+		foreach($tagArray as $tagKey=>$fields)
+		{
+			// Print the parent
+			$html .= '<li><a href="'.HTML_PATH_ROOT.$filter.'/'.$fields['tagKey'].'">'.$fields['name'].' ('.$fields['count'].')</a></li>';
+		}
 		$html .= '</ul>';
  		$html .= '</div>';
  		$html .= '</div>';


### PR DESCRIPTION
Enable sorting of the tags shown when using the tags plugin. Options
for sorting are "Alphabetical", "Count" and "Date". Date is the
default as it is the current way of sorting.

Also, use PHP function ucfirst to beautify the tags list.

Translations added for en_US only.