### PR TITLE
Added SVG image support for uploads

### DIFF
--- a/bl-kernel/admin/themes/default/init.php
+++ b/bl-kernel/admin/themes/default/init.php
@@ -489,7 +489,7 @@ $(document).ready(function() {
 	{
 		type: "json",
 		action: HTML_PATH_ADMIN_ROOT+"ajax/uploader",
-		allow : "*.(jpg|jpeg|gif|png)",
+		allow : "*.(jpg|jpeg|gif|png|svg)",
 		params: {"type":"bludit-images-v8"},
 
 		loadstart: function() {

--- a/bl-kernel/ajax/uploader.php
+++ b/bl-kernel/ajax/uploader.php
@@ -47,11 +47,18 @@ if($type=='profilePicture')
 else {
 	// Generate the thumbnail
 	$Image = new Image();
-	$Image->setImage(PATH_TMP.'original'.'.'.$fileExtension, THUMBNAILS_WIDTH, THUMBNAILS_HEIGHT, 'crop');
-	$Image->saveImage(PATH_UPLOADS_THUMBNAILS.$tmpName, 100, true);
-
+	//Handling all other formats than svg
+	if (strcasecmp($fileExtension, 'svg') != 0) {
+		$Image->setImage(PATH_TMP.'original'.'.'.$fileExtension, THUMBNAILS_WIDTH, THUMBNAILS_HEIGHT, 'crop');
+		$Image->saveImage(PATH_UPLOADS_THUMBNAILS.$tmpName, 100, true);
+	}
 	// Move the original to the upload folder.
 	rename(PATH_TMP.'original'.'.'.$fileExtension, PATH_UPLOADS.$tmpName);
+	
+	//If it is a svg file, just save a copy in thumbnail-folder
+	if (strcasecmp($fileExtension, 'svg') == 0) {
+		copy(PATH_UPLOADS.$tmpName, PATH_UPLOADS_THUMBNAILS.$tmpName);
+	}
 }
 
 // Remove the Bludit temporary file.

--- a/bl-kernel/ajax/uploader.php
+++ b/bl-kernel/ajax/uploader.php
@@ -57,7 +57,7 @@ else {
 	
 	//If it is a svg file, just save a copy in thumbnail-folder
 	if (strcasecmp($fileExtension, 'svg') == 0) {
-		copy(PATH_UPLOADS.$tmpName, PATH_UPLOADS_THUMBNAILS.$tmpName);
+		symlink(PATH_UPLOADS.$tmpName, PATH_UPLOADS_THUMBNAILS.$tmpName);
 	}
 }
 


### PR DESCRIPTION
Upload SVG images implemented.
Tested with Chrome and Firefox.
SVG file cannot be uploaded as cover-image (I think Facebook for example doesn't support this) and profile-pictures.