### PR TITLE
Fixed translation and updated tags plugin

### DIFF
--- a/bl-kernel/dblanguage.class.php
+++ b/bl-kernel/dblanguage.class.php
@@ -48,7 +48,7 @@ class dbLanguage extends dbJSON
 			return $this->db[$key];
 		}
 
-		return '';
+		return $string;
 	}
 
 	// Returns translation.

--- a/bl-plugins/tags/languages/de_DE.json
+++ b/bl-plugins/tags/languages/de_DE.json
@@ -3,5 +3,9 @@
 	{
 		"name": "Anzeige aller Schlagwörter",
 		"description": "Anzeige aller Schlagwörter in der Seitenleiste (bei Themes mit Seitenleiste)."
-	}
+	},
+    "sort-the-tag-list-by": "Sortierung der Schlagwörter nach",
+	"alphabetical-order": "Alphabetische Reihenfolge",
+	"number-of-times-each-tag-has-been-used": "Anzahl der Verwendung",
+	"date-each-tag-was-first-used": "Datum der ersten Verwendung"
 }

--- a/bl-plugins/tags/languages/en_US.json
+++ b/bl-plugins/tags/languages/en_US.json
@@ -3,9 +3,5 @@
 	{
 		"name": "Tags list",
 		"description": "Shows all tags."
-	},
-	"tag-sort-order": "Sort the tag list by",
-	"tag-sort-alphabetical": "Alphabetical order",
-	"tag-sort-count": "Number of times each tag has been used",
-	"tag-sort-date": "Date each tag was first used"
+	}
 }

--- a/bl-plugins/tags/plugin.php
+++ b/bl-plugins/tags/plugin.php
@@ -20,9 +20,11 @@ class pluginTags extends Plugin {
 		$html .= '</div>';
 
 		$html .= '<div>';
-		$html .= $Language->get('tag-sort-order').': <select name="sort">';
+		$html .= $Language->get('Sort the tag list by').': <select name="sort">';
 
-		foreach(array('alpha'=>'tag-sort-alphabetical', 'count'=>'tag-sort-count', 'date'=>'tag-sort-date') as $key=>$value) {
+		foreach(array('alpha' => 'Alphabetical order',
+		              'count' => 'Number of times each tag has been used',
+		              'date'  => 'Date each tag was first used') as $key=>$value) {
 			if ($key == $this->getDbField('sort')) {
 				$html .= '<option value="'.$key.'" selected>'.$Language->get($value).'</option>';
 			} else {


### PR DESCRIPTION
Instead of the default string $Language->get($string) previously
returned an empty string, breaking the default translation behaviour of
all default plugins except the tags plugin (which was fixed in the
course of the change).