### PR TITLE
patch OpenGraph plugin

### DIFF
--- a/bl-plugins/opengraph/plugin.php
+++ b/bl-plugins/opengraph/plugin.php
@@ -86,7 +86,7 @@ class pluginOpenGraph extends Plugin {
 			// Get the image from the content
 			$src = $this->getImage( $content );
 			if($src!==false) {
-				$html .= '<meta property="og:image" content="'.$urlImage.$og['image'].'">'.PHP_EOL;
+				$html .= '<meta property="og:image" content="'.$urlImage.str_replace(HTML_PATH_UPLOADS,'',$src).'">'.PHP_EOL;
 			}
 		}
 		else


### PR DESCRIPTION
`$og['image']` **is** `false` in this segment. So, no reason to use it as suffix to the image url.