### PR TITLE
Display only published pages in header menu

### DIFF
--- a/bl-themes/future-imperfect/index.php
+++ b/bl-themes/future-imperfect/index.php
@@ -26,6 +26,9 @@ MIT license
 				<?php
 					$parents = $pagesParents[NO_PARENT_CHAR];
 					foreach($parents as $Parent) {
+					// Check if the parent is published
+                                		if( $Parent->published() )
+                            			{  
 						echo '<li><a href="'.$Parent->permalink().'">'.$Parent->title().'</a></li>';
 					}
 				?>


### PR DESCRIPTION
Dignajar fixed bug where header menu was including draft pages as well. This will only allow pages with published status to be listed in the menu.