### PR TITLE
Look for .htaccess only on Apache or LiteSpeed

### DIFF
--- a/install.php
+++ b/install.php
@@ -190,7 +190,7 @@ function checkSystem()
 		$phpModules = get_loaded_extensions();
 	}
 	
-	if ((stripos($_SERVER['SERVER_SOFTWARE'], 'Apache') !== false || stripos($_SERVER['SERVER_SOFTWARE'], 'LiteSpeed') !== false) && !file_exists(PATH_ROOT.'.htaccess')) {
+	if (array_key_exists('SERVER_SOFTWARE', $_SERVER) && ((stripos($_SERVER['SERVER_SOFTWARE'], 'Apache') !== false || stripos($_SERVER['SERVER_SOFTWARE'], 'LiteSpeed') !== false) && !file_exists(PATH_ROOT.'.htaccess'))) {
 		$errorText = 'Missing file, upload the file .htaccess (ERR_201)';
 		error_log($errorText, 0);
 

--- a/install.php
+++ b/install.php
@@ -189,9 +189,8 @@ function checkSystem()
 	if(function_exists('get_loaded_extensions')) {
 		$phpModules = get_loaded_extensions();
 	}
-
-	if(!file_exists(PATH_ROOT.'.htaccess'))
-	{
+	
+	if ((stripos($_SERVER['SERVER_SOFTWARE'], 'Apache') !== false || stripos($_SERVER['SERVER_SOFTWARE'], 'LiteSpeed') !== false) && !file_exists(PATH_ROOT.'.htaccess')) {
 		$errorText = 'Missing file, upload the file .htaccess (ERR_201)';
 		error_log($errorText, 0);
 


### PR DESCRIPTION
Doesn't make any sense to look for a .htaccess file if bludit is running on other web server that isn't Apache or Litespeed. I've just placed a small verification to not generate errors if you try to install it using Nginx, for example, and the .htaccess file isn't in place.