### PR TITLE
Patch for "failed to load external entity" errors in DOMDocument::load calls

### DIFF
--- a/bl-plugins/rss/plugin.php
+++ b/bl-plugins/rss/plugin.php
@@ -95,7 +95,9 @@ class pluginRSS extends Plugin {
 			$doc = new DOMDocument();
 
 			// Load XML
+			libxml_disable_entity_loader(false);
 			$doc->load(PATH_PLUGINS_DATABASES.$this->directoryName.DS.'rss.xml');
+			libxml_disable_entity_loader(true);
 
 			// Print the XML
 			echo $doc->saveXML();

--- a/bl-plugins/sitemap/plugin.php
+++ b/bl-plugins/sitemap/plugin.php
@@ -137,7 +137,9 @@ class pluginSitemap extends Plugin {
 			$doc = new DOMDocument();
 
 			// Load XML
+			libxml_disable_entity_loader(false);
 			$doc->load(PATH_PLUGINS_DATABASES.$this->directoryName.DS.'sitemap.xml');
+			libxml_disable_entity_loader(true);
 
 			// Print the XML
 			echo $doc->saveXML();


### PR DESCRIPTION
If running Bludit inside same PHP/FastCGI instance with other scripts calling libxml_disable_entity_loader(true), call to DOMDocument::load fails with "I/O warning : failed to load external entity". See [here](https://bugs.php.net/bug.php?id=62577) for details in PHP bugtracker. Added suggested workaround to sitemap and RSS plugins.