### PR TITLE
Icons in the Plugins and Themes pages

### DIFF
--- a/bl-kernel/admin/themes/default/css/default.css
+++ b/bl-kernel/admin/themes/default/css/default.css
@@ -594,6 +594,7 @@ tr.theme-installed {
 div.plugin-name i.settings-icon {
 	float: right;
 	margin-top: 3px;
+	margin-left: 3px;
 }
 
 div.plugin-links > a {

--- a/bl-kernel/admin/themes/default/css/default.css
+++ b/bl-kernel/admin/themes/default/css/default.css
@@ -597,6 +597,10 @@ div.plugin-name i.settings-icon {
 	margin-left: 3px;
 }
 
+i.incompatible-warning {
+	color: #daa520;
+}
+
 div.plugin-links > a {
 	display: inline-block;
 	margin-top: 5px;

--- a/bl-kernel/admin/themes/default/css/default.css
+++ b/bl-kernel/admin/themes/default/css/default.css
@@ -591,6 +591,11 @@ tr.theme-installed {
 	background: #F2F7FF !important;
 }
 
+div.plugin-name i.settings-icon {
+	float: right;
+	margin-top: 3px;
+}
+
 div.plugin-links > a {
 	display: inline-block;
 	margin-top: 5px;

--- a/bl-kernel/admin/views/plugins.php
+++ b/bl-kernel/admin/views/plugins.php
@@ -46,7 +46,7 @@ foreach($plugins['all'] as $Plugin)
 
 	echo '
 	<td class="uk-text-center">'.$Plugin->version().'</td>
-	<td class="uk-text-center"><a targe="_blank" href="'.$Plugin->website().'">'.$Plugin->author().'</a></td>
+	<td class="uk-text-center"><a target="_blank" href="'.$Plugin->website().'">'.$Plugin->author().'</a></td>
 	';
 
 	echo '</tr>';

--- a/bl-kernel/admin/views/plugins.php
+++ b/bl-kernel/admin/views/plugins.php
@@ -20,25 +20,21 @@ foreach($plugins['all'] as $Plugin)
 	echo '
 	<tr '.($Plugin->installed()?'class="plugin-installed"':'class="plugin-notInstalled"').'>
 	<td>
-	<div class="plugin-name">'.$Plugin->name().'</div>
-	<div class="plugin-links">
+	<div class="plugin-name">
 	';
 
 	if($Plugin->installed()) {
+		echo '<a class="uninstall" href="'.HTML_PATH_ADMIN_ROOT.'uninstall-plugin/'.$Plugin->className().'" title="'.$L->g('Deactivate').'"><i class="uk-icon-check-square-o"></i></a> ';
 		if(method_exists($Plugin, 'form')) {
-			echo '<a class="configure" href="'.HTML_PATH_ADMIN_ROOT.'configure-plugin/'.$Plugin->className().'">'.$L->g('Settings').'</a>';
-			echo '<span class="separator"> | </span>';
+			echo '<a class="configure" href="'.HTML_PATH_ADMIN_ROOT.'configure-plugin/'.$Plugin->className().'" title="'.$L->g('Settings').'"><i class="uk-icon-cog settings-icon"></i></a> ';
 		}
-		echo '<a class="uninstall" href="'.HTML_PATH_ADMIN_ROOT.'uninstall-plugin/'.$Plugin->className().'">'.$L->g('Deactivate').'</a>';
 	}
 	else {
-		echo '<a class="install" href="'.HTML_PATH_ADMIN_ROOT.'install-plugin/'.$Plugin->className().'">'.$L->g('Activate').'</a>';
+		echo '<a class="install" href="'.HTML_PATH_ADMIN_ROOT.'install-plugin/'.$Plugin->className().'" title="'.$L->g('Activate').'"><i class="uk-icon-square-o"></i></a> ';
 	}
 
-
-
 	echo '
-	</div>
+	'.$Plugin->name().'</div>
 	</td>';
 
 	echo '<td>';

--- a/bl-kernel/admin/views/plugins.php
+++ b/bl-kernel/admin/views/plugins.php
@@ -39,13 +39,15 @@ foreach($plugins['all'] as $Plugin)
 
 	echo '<td>';
 	echo $Plugin->description();
-	if( !$Plugin->isCompatible() ) {
-		echo '<div class="plugin-incompatible"><i class="uk-icon-exclamation-triangle"></i> This plugin is incompatible with Bludit v'.BLUDIT_VERSION.'</div>';
-	}
 	echo '</td>';
+	echo '
+	<td class="uk-text-center">';
+	if( !$Plugin->isCompatible() ) {
+		echo '<i class="uk-icon-exclamation-triangle incompatible-warning" title="This plugin is incompatible with Bludit v'.BLUDIT_VERSION.'"></i>';
+	}
+	echo $Plugin->version().'</td>';
 
 	echo '
-	<td class="uk-text-center">'.$Plugin->version().'</td>
 	<td class="uk-text-center"><a target="_blank" href="'.$Plugin->website().'">'.$Plugin->author().'</a></td>
 	';
 

--- a/bl-kernel/admin/views/plugins.php
+++ b/bl-kernel/admin/views/plugins.php
@@ -40,7 +40,7 @@ foreach($plugins['all'] as $Plugin)
 	echo '<td>';
 	echo $Plugin->description();
 	if( !$Plugin->isCompatible() ) {
-		echo '<div class="plugin-incompatible">This plugin is incompatible with Bludit v'.BLUDIT_VERSION.'</div>';
+		echo '<div class="plugin-incompatible"><i class="uk-icon-exclamation-triangle"></i> This plugin is incompatible with Bludit v'.BLUDIT_VERSION.'</div>';
 	}
 	echo '</td>';
 

--- a/bl-kernel/admin/views/themes.php
+++ b/bl-kernel/admin/views/themes.php
@@ -38,7 +38,7 @@ foreach($themes as $theme)
 	echo $theme['description'];
 
 	if( !$theme['compatible'] ) {
-		echo '<div class="theme-incompatible">This theme is incompatible with Bludit v'.BLUDIT_VERSION.'</div>';
+		echo '<div class="theme-incompatible"><i class="uk-icon-exclamation-triangle"></i> This theme is incompatible with Bludit v'.BLUDIT_VERSION.'</div>';
 	}
 	echo '</td>';
 

--- a/bl-kernel/admin/views/themes.php
+++ b/bl-kernel/admin/views/themes.php
@@ -44,7 +44,7 @@ foreach($themes as $theme)
 
 	echo '
 	<td class="uk-text-center">'.$theme['version'].'</td>
-	<td class="uk-text-center"><a targe="_blank" href="'.$theme['website'].'">'.$theme['author'].'</a></td>
+	<td class="uk-text-center"><a target="_blank" href="'.$theme['website'].'">'.$theme['author'].'</a></td>
 	';
 
 	echo '</tr>';

--- a/bl-kernel/admin/views/themes.php
+++ b/bl-kernel/admin/views/themes.php
@@ -36,14 +36,16 @@ foreach($themes as $theme)
 
 	echo '<td>';
 	echo $theme['description'];
+	echo '</td>';
+	echo '
+	<td class="uk-text-center">';
 
 	if( !$theme['compatible'] ) {
-		echo '<div class="theme-incompatible"><i class="uk-icon-exclamation-triangle"></i> This theme is incompatible with Bludit v'.BLUDIT_VERSION.'</div>';
+		echo '<i class="uk-icon-exclamation-triangle incompatible-warning" title="This theme is incompatible with Bludit v'.BLUDIT_VERSION.'"></i>';
 	}
-	echo '</td>';
+	echo $theme['version'].'</td>';
 
 	echo '
-	<td class="uk-text-center">'.$theme['version'].'</td>
 	<td class="uk-text-center"><a target="_blank" href="'.$theme['website'].'">'.$theme['author'].'</a></td>
 	';
 

--- a/bl-kernel/admin/views/themes.php
+++ b/bl-kernel/admin/views/themes.php
@@ -20,16 +20,18 @@ foreach($themes as $theme)
 	echo '
 	<tr '.($theme['dirname']==$Site->theme()?'class="theme-installed"':'class="theme-notInstalled"').'>
 	<td>
-	<div class="plugin-name">'.$theme['name'].'</div>
-	<div class="plugin-links">
+	<div class="plugin-name">
 	';
 
 	if($theme['dirname']!=$Site->theme()) {
-		echo '<a class="install" href="'.HTML_PATH_ADMIN_ROOT.'install-theme/'.$theme['dirname'].'">'.$L->g('Activate').'</a>';
+		echo '<a class="install" href="'.HTML_PATH_ADMIN_ROOT.'install-theme/'.$theme['dirname'].'" title="'.$L->g('Activate').'"><i class="uk-icon-square-o"></i></a> ';
+	}
+	else {
+		echo '<i class="uk-icon-check-square-o"></i> ';
 	}
 
 	echo '
-	</div>
+	'.$theme['name'].'</div>
 	</td>';
 
 	echo '<td>';


### PR DESCRIPTION
Originally the Plugins page looked like this. It is difficult to see which plugins are active or have settings pages, as you have to read the words.

![plugin-old](https://cloud.githubusercontent.com/assets/6047296/23857157/27af17b2-0837-11e7-9801-5e81d3cb073b.PNG)

I've changed to use icons instead, which gives a clean look and it's easy now to identify the plugins that are active and have settings. The words are still used, as tooltips that appear when you hover on the icons.

![plugin-new](https://cloud.githubusercontent.com/assets/6047296/23857161/325589e4-0837-11e7-8ff8-0ec5f96d9127.PNG)

Similar changes applied to Themes page as well. Kindly view the commit messages themselves for more details.

**Side note:** In a separate commit, I also corrected a spelling mistake in a link attribute name which caused the author links to open in the same tab instead of a new tab.