### PR TITLE
Added a trailing / to evade an error

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,11 +5,14 @@ AddDefaultCharset UTF-8
 # Enable rewrite rules
 RewriteEngine on
 
+# Make this Folder our base
+RewriteBase /
+
 # Deny direct access to .txt files
 RewriteRule ^bl-content/(.*)\.txt$ - [R=404,L]
 
 # All URL process by index.php
 RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule ^(.*) index.php [PT,L]
+RewriteRule ^(.*) index.php/ [PT,L]
 
 </IfModule>


### PR DESCRIPTION
Added the trailing / after index.php to evade an internal server error on the Uberspace Apache installation were the lack of this broke the site, it internally replaced the URL-Path contents e.g. with index.phpadmin/ which won't work.

Also added a rule to make this folder our DocumentRoot, since this site is mostly run under domains/subdomains.

May be an issue related to my RedirectRule from HTTP to HTTPS placed in all DocumentRoots:

#RewriteCond %{HTTPS} !=on
#RewriteCond %{ENV:HTTPS} !=on
#RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [R=301,L]