### PR TITLE
Unique identifiers for posts and pages

### DIFF
--- a/bl-kernel/abstract/content.class.php
+++ b/bl-kernel/abstract/content.class.php
@@ -136,6 +136,12 @@ class Content {
 		return $this->getField('readMore');
 	}
 
+	// Returns the unique identifier
+	public function uniqueId()
+	{
+		return $this->getField('uniqueId');
+	}
+
 	// Returns the field key
 	public function key()
 	{
@@ -291,6 +297,7 @@ class Content {
 	public function json($returnsArray=false)
 	{
 		$tmp['key'] 		= $this->key();
+		$tmp['uniqueId'] 		= $this->uniqueId();
 		$tmp['title'] 		= $this->title();
 		$tmp['content'] 	= $this->content(); // Markdown parsed
 		$tmp['contentRaw'] 	= $this->contentRaw(); // No Markdown parsed

--- a/bl-kernel/admin/controllers/dashboard.php
+++ b/bl-kernel/admin/controllers/dashboard.php
@@ -32,6 +32,12 @@ function updateBludit()
 				$checksum = md5_file(PATH_POSTS.$key.DS.FILENAME);
 				$dbPosts->setPostDb($key, 'md5file', $checksum);
 			}
+			
+			// Unique identifier
+			if( empty($post['uniqueId']) ) {
+				$uniqueId = generateUniqueId();
+				$dbPosts->setPostDb($key, 'uniqueId', $uniqueId);
+			}
 		}
 
 		$dbPosts->save();
@@ -51,6 +57,12 @@ function updateBludit()
 			if( empty($post['md5file']) ) {
 				$checksum = md5_file(PATH_PAGES.$key.DS.FILENAME);
 				$dbPages->setPageDb($key, 'md5file', $checksum);
+			}
+			
+			// Unique identifier
+			if( empty($page['uniqueId']) ) {
+				$uniqueId = generateUniqueId();
+				$dbPages->setPageDb($key, 'uniqueId', $uniqueId);
 			}
 		}
 

--- a/bl-kernel/admin/controllers/dashboard.php
+++ b/bl-kernel/admin/controllers/dashboard.php
@@ -54,7 +54,7 @@ function updateBludit()
 			}
 
 			// Checksum
-			if( empty($post['md5file']) ) {
+			if( empty($page['md5file']) ) {
 				$checksum = md5_file(PATH_PAGES.$key.DS.FILENAME);
 				$dbPages->setPageDb($key, 'md5file', $checksum);
 			}

--- a/bl-kernel/admin/views/edit-page.php
+++ b/bl-kernel/admin/views/edit-page.php
@@ -16,6 +16,12 @@ HTML::formOpen(array('class'=>'uk-form-stacked'));
 		'value'=>$_Page->key()
 	));
 
+	// Unique identifier
+	HTML::formInputHidden(array(
+		'name'=>'uniqueId',
+		'value'=>$_Page->uniqueId()
+	));
+
 // LEFT SIDE
 // --------------------------------------------------------------------
 echo '<div class="uk-grid uk-grid-medium">';

--- a/bl-kernel/admin/views/edit-post.php
+++ b/bl-kernel/admin/views/edit-post.php
@@ -16,6 +16,12 @@ HTML::formOpen(array('class'=>'uk-form-stacked'));
 		'value'=>$_Post->key()
 	));
 
+	// Unique identifier
+	HTML::formInputHidden(array(
+		'name'=>'uniqueId',
+		'value'=>$_Post->uniqueId()
+	));
+
 // LEFT SIDE
 // --------------------------------------------------------------------
 echo '<div class="uk-grid uk-grid-medium">';

--- a/bl-kernel/boot/init.php
+++ b/bl-kernel/boot/init.php
@@ -273,3 +273,9 @@ $Url->checkFilters( $Site->uriFilters() );
 
 // --- Objects shortcuts ---
 $L = $Language;
+
+// Function for generating unique identifiers
+function generateUniqueId()
+{
+	return md5(uniqid('', true));
+}

--- a/bl-kernel/dbpages.class.php
+++ b/bl-kernel/dbpages.class.php
@@ -7,6 +7,7 @@ class dbPages extends dbJSON
 	private $dbFields = array(
 		'title'=>		array('inFile'=>true,	'value'=>''),
 		'content'=>		array('inFile'=>true,	'value'=>''),
+		'uniqueId'=>		array('inFile'=>false,	'value'=>''),
 		'description'=>		array('inFile'=>false,	'value'=>''),
 		'username'=>		array('inFile'=>false,	'value'=>''),
 		'tags'=>		array('inFile'=>false,	'value'=>array()),
@@ -28,6 +29,11 @@ class dbPages extends dbJSON
 		$dataForFile = array(); // This data will be saved in the file
 
 		$key = $this->generateKey($args['slug'], $args['parent']);
+		
+		// Generate unique identifier
+		if( empty($args['uniqueId']) ) {
+			$args['uniqueId'] = generateUniqueId();
+		}
 
 		// The user is always the one loggued.
 		$args['username'] = Session::get('username');
@@ -105,6 +111,11 @@ class dbPages extends dbJSON
 		$dataForFile = array();
 
 		$newKey = $this->generateKey($args['slug'], $args['parent'], false, $args['key']);
+		
+		// Generate unique identifier
+		if( empty($args['uniqueId']) ) {
+			$args['uniqueId'] = generateUniqueId();
+		}
 
 		// The user is always the one loggued.
 		$args['username'] = Session::get('username');

--- a/bl-kernel/dbposts.class.php
+++ b/bl-kernel/dbposts.class.php
@@ -5,6 +5,7 @@ class dbPosts extends dbJSON
 	private $dbFields = array(
 		'title'=>		array('inFile'=>true,	'value'=>''),
 		'content'=>		array('inFile'=>true,	'value'=>''),
+		'uniqueId'=>		array('inFile'=>false,	'value'=>''),
 		'description'=>		array('inFile'=>false,	'value'=>''),
 		'username'=>		array('inFile'=>false,	'value'=>''),
 		'status'=>		array('inFile'=>false,	'value'=>'draft'), // published, draft, scheduled
@@ -113,6 +114,11 @@ class dbPosts extends dbJSON
 
 		// Generate the database key / index
 		$key = $this->generateKey($args['slug']);
+		
+		// Generate unique identifier
+		if( empty($args['uniqueId']) ) {
+			$args['uniqueId'] = generateUniqueId();
+		}
 
 		// The user is always who is loggued
 		$args['username'] = Session::get('username');

--- a/bl-plugins/disqus/plugin.php
+++ b/bl-plugins/disqus/plugin.php
@@ -8,9 +8,9 @@ class pluginDisqus extends Plugin {
 	{
 		$this->dbFields = array(
 			'shortname'=>'',
-			'enablePages'=>0,
-			'enablePosts'=>0,
-			'enableDefaultHomePage'=>1
+			'enablePages'=>1,
+			'enablePosts'=>1,
+			'enableDefaultHomePage'=>0
 		);
 	}
 

--- a/bl-plugins/disqus/plugin.php
+++ b/bl-plugins/disqus/plugin.php
@@ -98,12 +98,42 @@ class pluginDisqus extends Plugin {
 
 	public function siteBodyEnd()
 	{
+		global $Page, $Post, $Url, $posts;
+		
+		switch($Url->whereAmI())
+		{
+			case 'post':
+				$absolutePermalink = $Post->permalink(true);
+				$uniqueId = $Post->uniqueId();
+				$disqusTitle = $Post->title();
+				break;
+			case 'page':
+				$absolutePermalink = $Page->permalink(true);
+				$uniqueId = $Page->uniqueId();
+				$disqusTitle = $Page->title();
+				break;
+				
+			default:
+				// Homepage - use the first post
+				if(isset($posts[0])) {
+					$absolutePermalink = $posts[0]->permalink(true);
+					$uniqueId = $posts[0]->uniqueId();
+					$disqusTitle = $posts[0]->title();
+				}
+		}
+		
 		if( $this->enable ) {
 
 			$html = '
 <script type="text/javascript">
 
 	var disqus_shortname = "'.$this->getDbField('shortname').'";
+
+	var disqus_config = function () {
+		this.page.url = "'.$absolutePermalink.'";
+		this.page.identifier = "'.$uniqueId.'";
+		this.page.title = "'.$disqusTitle.'";
+	};
 
 	(function() {
 	var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;


### PR DESCRIPTION
See issue #409 for more details.

The unique identifier is permanently attached to the post or page and doesn't change during its lifetime. It can be used for many purposes that require identification, such as Disqus comment threads (to avoid thread duplication), redirection of old URLs, etc.

This avoids thread splitting, duplication, and other problems in Disqus, as discussed at:
https://help.disqus.com/customer/en/portal/articles/2158629

PS: If you're not upgrading Bludit, you will need to open `/admin/dashboard?update` to force adding identifiers to existing posts and pages.

_Also:_

- Fix a mistake in dashboard.php (`$post` instead of `$page`).
- Reverse the defaults in Disqus plugin settings: Pages and posts to have commments by default, while home page to not.