### PR TITLE
PNG transparency fix + Quill fix + Content input area fix

### DIFF
--- a/bl-kernel/admin/views/edit-page.php
+++ b/bl-kernel/admin/views/edit-page.php
@@ -29,13 +29,16 @@ echo '<div class="bl-publish-view uk-width-8-10">';
 		'placeholder'=>$L->g('Title')
 	));
 
+	echo '<div style="padding-top: 10px"></div>';
+
 	// Content input
-	HTML::formTextarea(array(
-		'name'=>'content',
-		'value'=>$_Page->contentRaw(false),
-		'class'=>'uk-width-1-1 uk-form-large',
-		'placeholder'=>''
-	));
+	// HTML::formTextarea(array(
+	// 	'name'=>'content',
+	// 	'value'=>$_Post->contentRaw(false),
+	// 	'class'=>'uk-width-1-1 uk-form-large',
+	// 	'placeholder'=>''
+	// ));
+	echo '<div id="jscontent" name="content" class="uk-width-1-1 uk-form-large" placeholder="" value="'.$_Post->contentRaw(false).'" style="margin-bottom: 10px"></div>';
 
 	// Form buttons
 	echo '<div class="uk-form-row uk-margin-bottom">';
@@ -239,7 +242,7 @@ $(document).ready(function()
 		}
 		else {
 			$(".sidebar-view").hide();
-			$(view).show();			
+			$(view).show();
 		}
 	});
 

--- a/bl-kernel/admin/views/edit-post.php
+++ b/bl-kernel/admin/views/edit-post.php
@@ -29,13 +29,16 @@ echo '<div class="bl-publish-view uk-width-8-10">';
 		'placeholder'=>$L->g('Title')
 	));
 
+	echo '<div style="padding-top: 10px"></div>';
+
 	// Content input
-	HTML::formTextarea(array(
-		'name'=>'content',
-		'value'=>$_Post->contentRaw(false),
-		'class'=>'uk-width-1-1 uk-form-large',
-		'placeholder'=>''
-	));
+	// HTML::formTextarea(array(
+	// 	'name'=>'content',
+	// 	'value'=>$_Post->contentRaw(false),
+	// 	'class'=>'uk-width-1-1 uk-form-large',
+	// 	'placeholder'=>''
+	// ));
+	echo '<div id="jscontent" name="content" class="uk-width-1-1 uk-form-large" placeholder="" value="'.$_Post->contentRaw(false).'" style="margin-bottom: 10px"></div>';
 
 	// Form buttons
 	echo '<div class="uk-form-row uk-margin-bottom">
@@ -197,7 +200,7 @@ $(document).ready(function() {
 		}
 		else {
 			$(".sidebar-view").hide();
-			$(view).show();			
+			$(view).show();
 		}
 	});
 

--- a/bl-kernel/admin/views/new-page.php
+++ b/bl-kernel/admin/views/new-page.php
@@ -23,13 +23,16 @@ echo '<div class="bl-publish-view uk-width-8-10">';
 		'placeholder'=>$L->g('Title')
 	));
 
+	echo '<div style="padding-top: 10px"></div>';
+	
 	// Content input
-	HTML::formTextarea(array(
-		'name'=>'content',
-		'value'=>'',
-		'class'=>'uk-width-1-1 uk-form-large',
-		'placeholder'=>''
-	));
+	// HTML::formTextarea(array(
+	// 	'name'=>'content',
+	// 	'value'=>'',
+	// 	'class'=>'uk-width-1-1 uk-form-large',
+	// 	'placeholder'=>''
+	// ));
+	echo '<div id="jscontent" name="content" class="uk-width-1-1 uk-form-large" placeholder="" style="margin-bottom: 10px"></div>';
 
 	// Form buttons
 	echo '<div class="uk-form-row uk-margin-bottom">
@@ -212,7 +215,7 @@ $(document).ready(function()
 		}
 		else {
 			$(".sidebar-view").hide();
-			$(view).show();			
+			$(view).show();
 		}
 	});
 

--- a/bl-kernel/admin/views/new-post.php
+++ b/bl-kernel/admin/views/new-post.php
@@ -23,13 +23,16 @@ echo '<div class="bl-publish-view uk-width-8-10">';
 		'placeholder'=>$L->g('Title')
 	));
 
+	echo '<div style="padding-top: 10px"></div>';
+
 	// Content input
-	HTML::formTextarea(array(
-		'name'=>'content',
-		'value'=>'',
-		'class'=>'uk-width-1-1 uk-form-large',
-		'placeholder'=>''
-	));
+	// HTML::formTextarea(array(
+	// 	'name'=>'content',
+	// 	'value'=>'',
+	// 	'class'=>'uk-width-1-1 uk-form-large',
+	// 	'placeholder'=>''
+	// ));
+	echo '<div id="jscontent" name="content" class="uk-width-1-1 uk-form-large" placeholder="" style="margin-bottom: 10px"></div>';
 
 	// Form buttons
 	echo '<div class="uk-form-row uk-margin-bottom">
@@ -73,7 +76,7 @@ echo '<div class="bl-publish-sidebar uk-width-2-10">';
 	));
 
 	echo '</li>';
-	
+
 	// IMAGES TAB
 	// --------------------------------------------------------------------
 	echo '<li><h2 class="sidebar-button" data-view="sidebar-images-view"><i class="uk-icon-angle-down"></i> '.$L->g('Images').'</h2></li>';
@@ -182,7 +185,7 @@ $(document).ready(function() {
 		}
 		else {
 			$(".sidebar-view").hide();
-			$(view).show();			
+			$(view).show();
 		}
 	});
 

--- a/bl-kernel/helpers/image.class.php
+++ b/bl-kernel/helpers/image.class.php
@@ -108,6 +108,8 @@ class Image {
 
 		// *** Resample - create image canvas of x, y size
 		$this->imageResized = imagecreatetruecolor($optimalWidth, $optimalHeight);
+		imagealphablending($this->imageResized, false);
+		imagesavealpha($this->imageResized, true);
 		imagecopyresampled($this->imageResized, $this->image, 0, 0, 0, 0, $optimalWidth, $optimalHeight, $this->width, $this->height);
 
 
@@ -230,6 +232,8 @@ class Image {
 
 		// *** Now crop from center to exact requested size
 		$this->imageResized = imagecreatetruecolor($newWidth , $newHeight);
+		imagealphablending($this->imageResized, false);
+		imagesavealpha($this->imageResized, true);
 		imagecopyresampled($this->imageResized, $crop , 0, 0, $cropStartX, $cropStartY, $newWidth, $newHeight , $newWidth, $newHeight);
 	}
 }

--- a/bl-plugins/quill/languages/en_US.json
+++ b/bl-plugins/quill/languages/en_US.json
@@ -2,6 +2,6 @@
 	"plugin-data":
 	{
 		"name": "Quill",
-		"description": ""
+		"description": "Quill is a free, open source WYSIWYG editor built for the modern web. With its modular architecture and expressive API, it is completely customizable to fit any need."
 	}
 }

--- a/bl-plugins/quill/plugin.php
+++ b/bl-plugins/quill/plugin.php
@@ -56,7 +56,7 @@ class pluginQuill extends Plugin {
 		$html .= '<input name="autosave" id="jsautosave" type="checkbox" value="1" '.($this->getDbField('autosave')?'checked':'').'>';
 		$html .= '<label class="forCheckbox" for="jsautosave">'.$Language->get('Autosave').'</label>';
 		$html .= '</div>';
-		
+
 		$html .= '<div>';
 		$html .= '<input type="hidden" name="spellChecker" value="0">';
 		$html .= '<input name="spellChecker" id="jsspellChecker" type="checkbox" value="1" '.($this->getDbField('spellChecker')?'checked':'').'>';
@@ -72,21 +72,39 @@ class pluginQuill extends Plugin {
 		global $Language;
 
 		$html = '';
-		if( $this->enabled() ) {
+		// Load CSS and JS only on Controllers in array.
+		if(in_array($layout['controller'], $this->loadWhenController))
+		{
 			$html .= '
 			<script>
 
-var quill = new Quill("#editor-container", {
-  modules: {
-    toolbar: [
-      [{ header: [1, 2, false] }],
-      ["bold", "italic", "underline"],
-      ["image"]
-    ]
-  },
-  placeholder: "asd",
-  theme: "snow"
-});
+				var toolbarOptions = [
+						["bold", "italic", "underline", "strike"],        // toggled buttons
+						["blockquote", "code-block"],
+
+						[{ "header": 1 }, { "header": 2 }],               // custom button values
+						[{ "list": "ordered"}, { "list": "bullet" }],
+						[{ "script": "sub"}, { "script": "super" }],      // superscript/subscript
+						[{ "indent": "-1"}, { "indent": "+1" }],          // outdent/indent
+						[{ "direction": "rtl" }],                         // text direction
+
+						[{ "size": ["small", false, "large", "huge"] }],  // custom dropdown
+						[{ "header": [1, 2, 3, 4, 5, 6, false] }],
+
+						[{ "color": [] }, { "background": [] }],          // dropdown with defaults from theme
+						[{ "font": [] }],
+						[{ "align": [] }],
+
+						["clean"]                                         // remove formatting button
+				];
+
+				var quill = new Quill("#jscontent", {
+				  modules: {
+				    toolbar: toolbarOptions
+				  },
+				  placeholder: "Compose an epic...",
+				  theme: "snow"
+				});
 			</script>
 			';
 		}


### PR DESCRIPTION
This is a 3 commit combo.

---

Transparency data will be saved when cropping or resizing.
See issue #417 .

---

Just making it work. It seems to be working fine on my end,
but user-defined toolbar options are not implemented yet.

The plugin now loads all toolbar options by default.
See: var toolbarOptions

---

This is to ensure that the area will be comaptible
with any text editor plugins.

I have tested with SimpleMDE and Quill. Both worked
completely fine.

Bonus: Added description of Quill's English locale.