### PR TITLE
Generate title (if empty) from the content.

### DIFF
--- a/bl-kernel/dbpages.class.php
+++ b/bl-kernel/dbpages.class.php
@@ -28,9 +28,17 @@ class dbPages extends dbJSON
 	{
 		$dataForDb = array();	// This data will be saved in the database
 		$dataForFile = array(); // This data will be saved in the file
-
+		
+		// Generate title 
+		if( empty($args['title']) ) {
+			$args['title'] = Text::truncate($args['content'], 60);
+			
+			// Assign the new title to the slug as well.
+			$args['slug'] = $args['title'];
+		}
+		
 		$key = $this->generateKey($args['slug'], $args['parent']);
-
+		
 		// Generate UUID
 		$args['uuid'] = md5(time().DOMAIN);
 

--- a/bl-kernel/dbposts.class.php
+++ b/bl-kernel/dbposts.class.php
@@ -111,7 +111,15 @@ class dbPosts extends dbJSON
 
 		// Current date, format of DB_DATE_FORMAT
 		$currentDate = Date::current(DB_DATE_FORMAT);
-
+		
+		// Generate title 
+		if( empty($args['title']) ) {
+			$args['title'] = Text::truncate($args['content'], 60);
+			
+			// Assign the new title to the slug as well.
+			$args['slug'] = $args['title'];
+		}
+		
 		// Generate the database key / index
 		$key = $this->generateKey($args['slug']);
 

--- a/bl-kernel/helpers/text.class.php
+++ b/bl-kernel/helpers/text.class.php
@@ -216,23 +216,22 @@ class Text {
 	// Truncates the string under the limit specified by the limit parameter.
 	public static function truncate($string, $limit, $end = '...')
 	{
-		
-		// Check if string is only one word
-		if(preg_match('/\s/', $string)) {
+		// Check if over $limit
+		if(mb_strlen($string) > $limit) {
 			
-			// Append the string specified by the end parameter to the end of the string as it is over the limit.
-			$truncate = trim(mb_substr($string, 0, mb_strpos($string, ' ', $limit, 'UTF-8'), 'UTF-8')).$end;
-			
-		} else {
-			$truncate = trim(mb_substr($string, 0, $limit, 'UTF-8'));
-			
-			// Check if string is more than limit
-			if(mb_strlen($string) > $limit) {
-				// Append $end
-				$truncate = $truncate.$end;
+			// Check if string is only one word
+			if(preg_match('/\s/', $string)) {
+				
+				// Append the string specified by the end parameter to the end of the string as it is over the limit.
+				$truncate = trim(mb_substr($string, 0, mb_strpos($string, ' ', $limit, 'UTF-8'), 'UTF-8'));
+			} else {
+				$truncate = trim(mb_substr($string, 0, $limit, 'UTF-8'));
 			}
+			$truncate = $truncate.$end;
+		} else {
+			$truncate = $string;
 		}
-
+		
 		if(empty($truncate)) {
 			return '';
 		}

--- a/bl-kernel/helpers/text.class.php
+++ b/bl-kernel/helpers/text.class.php
@@ -212,6 +212,33 @@ class Text {
 
 		return $cut;
 	}
+	
+	// Truncates the string under the limit specified by the limit parameter.
+	public static function truncate($string, $limit, $end = '...')
+	{
+		
+		// Check if string is only one word
+		if(preg_match('/\s/', $string)) {
+			
+			// Append the string specified by the end parameter to the end of the string as it is over the limit.
+			$truncate = trim(mb_substr($string, 0, mb_strpos($string, ' ', $limit, 'UTF-8'), 'UTF-8')).$end;
+			
+		} else {
+			$truncate = trim(mb_substr($string, 0, $limit, 'UTF-8'));
+			
+			// Check if string is more than limit
+			if(mb_strlen($string) > $limit) {
+				// Append $end
+				$truncate = $truncate.$end;
+			}
+		}
+
+		if(empty($truncate)) {
+			return '';
+		}
+
+		return $truncate;
+	}
 
 	// Return string length
 	public static function length($string)


### PR DESCRIPTION
A new function is created to achieve this, Text::truncate
which is based on Text::cut from the text.class.php helper.

Limit is set to 60 characters.

Example A:
1. Content has over 60 characters.
2. Title = First 60 characters + remaining characters of the last word + '...'

Example B:
1. Content has less than or equal to 60 characters
2. Title = All.

Example C:
1. Content only has one word but is over 60 characters.
2. Title = First 60 characters + '...'

Why B and C differ from each other?
Because we do not want the whole that one weird word
with over 60 characters to make its way to the title.
It's probably unrealistic, the code can be much cleaner
with B and C combined.

Feel free to discuss.