### PR TITLE
Added siteCSS & siteJavascript for plugins variables.

### DIFF
--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -9,6 +9,8 @@ $plugins = array(
 	'siteBodyBegin'=>array(),
 	'siteBodyEnd'=>array(),
 	'siteSidebar'=>array(),
+	'siteCSS'=>array(),
+	'siteJavascript'=>array(),
 	'beforeSiteLoad'=>array(),
 	'afterSiteLoad'=>array(),
 


### PR DESCRIPTION
To use with Theme::plugins('siteJavascript') to place all javascript files from plugins in the same place. Good to use when you want to place all .js files in end of body without use of siteBodyEnd.

I myself always want the .js files in the end of the body so they don't need to load before the site is rendered, so it won't be a white page.

Good to group all .css and .js files together for easier source code.